### PR TITLE
mysql.sockをignoreから外す

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /tmp/storage/*
 !/tmp/storage/
 !/tmp/storage/.keep
+!/tmp/mysql.sock
 
 /public/assets
 


### PR DESCRIPTION
デプロイ先でmysql.sockファイルを求められたため、ignoreから外した。